### PR TITLE
Yomitan template only works if results grouping mode is enabled

### DIFF
--- a/yomitanTemplate.hbs
+++ b/yomitanTemplate.hbs
@@ -68,10 +68,8 @@
     {{~/scope~}}
 {{/inline}}
 
-{{!~ extract the glossary entries with their tags ~}}
-{{#*inline "py-glossary"}}
-    {{~#each definition.definitions~}}
-        <div data-dictionary="{{~dictionary~}}">
+{{#*inline "py-glossary-single"~}}
+    <div data-dictionary="{{~dictionary~}}">
         {{~#each definitionTags~}}
             <i class="tag popup" data-type="tag" data-tag-name="{{~name~}}" data-tag-notes="{{~notes~}}" data-tag-category="{{~category~}}">{{~name~}}<span class="popup-text">{{~notes~}}</span></i>
         {{~/each~}}
@@ -82,6 +80,16 @@
                 <li data-type="glossary-entry">{{.}}</li>
             {{~/if~}}
         {{~/each~}}
-        </div>
-    {{~/each~}}
+    </div>
+{{~/inline}}
+
+{{!~ extract the glossary entries with their tags ~}}
+{{#*inline "py-glossary"}}
+    {{~#if (op "===" definition.type "term")~}}
+        {{~> py-glossary-single definition~}}
+    {{~else if (op "||" (op "===" definition.type "termGrouped") (op "===" definition.type "termMerged"))~}}
+        {{~#each definition.definitions~}}
+            {{~> py-glossary-single~}}
+        {{~/each~}}
+    {{~/if~}}
 {{/inline}}

--- a/yomitanTemplate.hbs
+++ b/yomitanTemplate.hbs
@@ -70,16 +70,16 @@
 
 {{#*inline "py-glossary-single"~}}
     <div data-dictionary="{{~dictionary~}}">
-        {{~#each definitionTags~}}
-            <i class="tag popup" data-type="tag" data-tag-name="{{~name~}}" data-tag-notes="{{~notes~}}" data-tag-category="{{~category~}}">{{~name~}}<span class="popup-text">{{~notes~}}</span></i>
-        {{~/each~}}
-        {{~#each glossary~}}
-            {{~#if (op "==" type "structured-content")~}}
-                {{~>py-unwrap-structured .~}}
-            {{~else~}}
-                <li data-type="glossary-entry">{{.}}</li>
-            {{~/if~}}
-        {{~/each~}}
+    {{~#each definitionTags~}}
+        <i class="tag popup" data-type="tag" data-tag-name="{{~name~}}" data-tag-notes="{{~notes~}}" data-tag-category="{{~category~}}">{{~name~}}<span class="popup-text">{{~notes~}}</span></i>
+    {{~/each~}}
+    {{~#each glossary~}}
+        {{~#if (op "==" type "structured-content")~}}
+            {{~>py-unwrap-structured .~}}
+        {{~else~}}
+            <li data-type="glossary-entry">{{.}}</li>
+        {{~/if~}}
+    {{~/each~}}
     </div>
 {{~/inline}}
 


### PR DESCRIPTION
This pull request addresses a small issue, which is that your Yomitan template only works if "results grouping mode" is set to one of the two on values. This should make it work regardless!